### PR TITLE
Jira 385

### DIFF
--- a/app/styles/_header.scss
+++ b/app/styles/_header.scss
@@ -13,8 +13,8 @@
 .navbar-nav > li.disabled{
 	& a:hover, & a:focus{
     background: transparent !important;
-		border-top-color: transparent !important;
-  	border-color: transparent !important;
-		cursor: default;
+    border-top-color: transparent !important;
+    border-color: transparent !important;
+    cursor: default;
 	}
 }

--- a/app/styles/_header.scss
+++ b/app/styles/_header.scss
@@ -10,3 +10,11 @@
     }
 }
 
+.navbar-nav > li.disabled{
+	& a:hover, & a:focus{
+    background: transparent !important;
+		border-top-color: transparent !important;
+  	border-color: transparent !important;
+		cursor: default;
+	}
+}


### PR DESCRIPTION
Notification icon should now act the same way as ozp-center when there are no notifications. Previously there would be a not-allowed cursor & a light gray background when you hover over the notification bell icon. Those have been removed. We should implement a common css for toolbar in ozp-react-commons.