### PR TITLE
Adding error and username checking to the Share Folder option in HUD

### DIFF
--- a/app/js/api/Library.js
+++ b/app/js/api/Library.js
@@ -16,7 +16,7 @@ module.exports.LibraryApi = {
             });
     },
 
-    share: function(folder, peer, message) {
+    share: function(folder, peer, message, fn) {
       if(message.replace(/\s/g, '').length == 0){
         message = 'shared folder'
       }
@@ -35,6 +35,20 @@ module.exports.LibraryApi = {
               "folder_name": folder
             }
           })
+      }).fail(function(response) {
+          if(peer == '') {
+              alert('Username not entered');
+          } else if(response.responseJSON && response.responseJSON.non_field_errors
+             && response.responseJSON.non_field_errors[0] == 'Valid User is Required'){
+              alert('The username "' + peer + '" was not found.  Please check the spelling');
+          } else {
+              alert('Error sharing folder.  Please try again.');
+          }
+          console.log('Error sharing folder: ', response.status,
+                  response.responseJSON || response.responseText);
+      }).done(() => {
+          fn();
+          LibraryActions.fetchLibrary();
       });
     },
 
@@ -88,7 +102,7 @@ module.exports.LibraryApi = {
                     response.status, response.responseJSON || response.responseText);
         });
     },
-    
+
     deleteFolder: function(appId) {
         return $.ajax({
             type: 'DELETE',

--- a/app/js/components/folder/FolderModal.jsx
+++ b/app/js/components/folder/FolderModal.jsx
@@ -127,10 +127,18 @@ var FolderModal = React.createClass({
         this.transitionTo('folder', {name: encodeURIComponent(newName)});
         this.onStoreUpdate();
     },
+
+    toggleURLState: function(){
+        this.setState({
+            shareURLToggle: !this.state.shareURLToggle
+        });
+    },
+
     render: function() {
 
         //undo the manual escaping of slashes that we must do because react-router doesn't
         var folderName = decodeURIComponent(this.props.params.name);
+        var fn = this.toggleURLState;
         var shareFolderButtonText = (!this.state.shareURLToggle ? 'Share ' + folderName : 'Back');
         return (
             <div ref="hastooltips" className="modal FolderModal" data-show="true"
@@ -172,15 +180,16 @@ var FolderModal = React.createClass({
                                   <textarea type="text" ref="message" className="form-control" ></textarea>
                                 </div>
                                 <div className="form-group">
-                                  <Link to="main" className="btn btn-primary" onClick={() => {
+                                  <button to="main" className="btn btn-primary" onClick={() => {
                                       LibraryActions.shareFolder({
                                         folder: folderName,
                                         peer: this.refs.peer.getDOMNode().value,
-                                        message: this.refs.message.getDOMNode().value
+                                        message: this.refs.message.getDOMNode().value,
+                                        fn: fn
                                       });
                                     }}>
                                     Send {folderName}
-                                  </Link>
+                                  </button>
                                 </div>
                               </div>
                             }

--- a/app/js/store/FolderLibrary.js
+++ b/app/js/store/FolderLibrary.js
@@ -181,7 +181,7 @@ var FolderLibraryStore = Reflux.createStore({
     },
 
     onShareFolder: function(payload) {
-      LibraryApi.share(payload.folder, payload.peer, payload.message);
+      LibraryApi.share(payload.folder, payload.peer, payload.message, payload.fn);
     },
 
     onDeleteFolder: function(folder) {


### PR DESCRIPTION
Initial prep needed (need a folder in HUD):
- Bookmark at least two apps from Center.
- Go to HUD, click and drag one bookmarked item over another to create a folder.

Open the folder in HUD and click the Share Folder button on the bottom right.

Tests:
- Click the 'Send Folder' button - Verify a notice is displayed to the user about an empty username field
- Enter an invalid user name (betttafish, test) - Verify a notice is displayed that the username appears to be incorrect.
- Enter a valid user name (bettafish) - Verify no notice is display to the user, the user is returned to the main page of the Folder.

@mleeBoeing @rkenyon1969 @lsemesky 