### PR TITLE
fix(profile): fix bugs in HUD profile window

### DIFF
--- a/app/js/components/library/FolderTile.jsx
+++ b/app/js/components/library/FolderTile.jsx
@@ -28,7 +28,9 @@ var FolderTile = React.createClass({
     },
 
     componentDidMount: function() {
-        ProfileActions.fetchProfile();
+        // assumes that FolderTile is ALWAYS being used as self
+        ProfileActions.fetchProfile('self');
+
         $('html').click(() => {
           if (this.isMounted()) {
             this.setState({checked: false});


### PR DESCRIPTION
**Description**

Fix bugs in the profile window on the HUD page.  These bugs are not present when opening the profile on the Center page.

**Acceptance Criteria**

Open the profile window in HUD:
1) Ensure that when loading listings, the spinner icon is centered and animates
2) Ensure that all profile information, including settings and subscriptions, are visible in the window.

Note that you can compare the HUD profile to the correctly working Center profile.  If you spot any differences, then there is a bug/issue.

**How to Test Code**

Pull `fix_profile` from `ozp-center`
Pull `fix_profile` from `ozp-hud`
Pull `fix_profile` from `ozp-react-commons`

Update `package.json` in HUD and Center to point to this branch or your local `ozp-react-commons` repo