### PR TITLE
Add Bookmark Folder link duplicates Bookmarks that already exist

### DIFF
--- a/app/js/actions/Library.js
+++ b/app/js/actions/Library.js
@@ -105,5 +105,11 @@ module.exports = Reflux.createActions([
     /**
      * Indicate that no specific folder is currently being viewed
      */
-    'stopViewingFolder'
+    'stopViewingFolder',
+
+    /**
+     * Remove notification after a foder is restored via undo button
+     * @param payload The id of the notification
+     */
+    'restoreFolderNotificationRemoval'
 ]);

--- a/app/js/actions/Library.js
+++ b/app/js/actions/Library.js
@@ -108,7 +108,7 @@ module.exports = Reflux.createActions([
     'stopViewingFolder',
 
     /**
-     * Remove notification after a foder is restored via undo button
+     * Remove notification after a folder is restored via undo button
      * @param payload The id of the notification
      */
     'restoreFolderNotificationRemoval'

--- a/app/js/api/Library.js
+++ b/app/js/api/Library.js
@@ -93,9 +93,9 @@ module.exports.LibraryApi = {
       });
     },
 
-    removeFolderNotification: function(notificaitonId){
+    removeFolderNotification: function(notificationId){
         return $.ajax({
-            url: `${API_URL}/api/notification/` + notificaitonId + '/',
+            url: `${API_URL}/api/notification/` + notificationId + '/',
             type: 'delete',
             dataType: 'json',
             contentType: 'application/json'
@@ -165,6 +165,8 @@ module.exports.LibraryApi = {
         }).fail(function(response) {
             console.error('Error removing folder containing Listing with id ' + appId + ' from library',
                     response.status, response.responseJSON || response.responseText);
+        }).done(() => {
+            LibraryActions.fetchLibrary();
         });
     }
 };

--- a/app/js/api/Library.js
+++ b/app/js/api/Library.js
@@ -93,18 +93,31 @@ module.exports.LibraryApi = {
       });
     },
 
+    removeFolderNotification: function(notificaitonId){
+        return $.ajax({
+            url: `${API_URL}/api/notification/` + notificaitonId + '/',
+            type: 'delete',
+            dataType: 'json',
+            contentType: 'application/json'
+        }).then(() => {
+            LibraryActions.fetchLibrary();
+            return;
+        });
+
+    },
+
     save: function(libraryEntries) {
         // Reorder Function
         var libraryEntriesList = libraryEntries.map(function(e,ind){
-                                                    var tempObj = {};
+            var tempObj = {};
 
-                                                    for(var i in e){
-                                                        tempObj[i] = e[i];
-                                                    }
+            for(var i in e){
+                tempObj[i] = e[i];
+            }
 
-                                                    tempObj.position = ind;
-                                                    return tempObj;
-                                                });
+            tempObj.position = ind;
+            return tempObj;
+        });
 
         return $.ajax({
             type: 'PUT',

--- a/app/js/components/folder/Add.jsx
+++ b/app/js/components/folder/Add.jsx
@@ -11,34 +11,34 @@ var LibraryStore = require('../../store/Library');
 var {HUD_URL} = require('OzoneConfig');
 
 var FolderModal = React.createClass({
-    mixins: [Reflux.listenTo(LibraryActions.hasLoaded, 'onfetchLibraryCompleted'), Reflux.connect(LibraryStore, "libraryStore"), Navigation, Reflux.listenerMixin],
+    mixins: [Reflux.listenTo(LibraryActions.hasLoaded, 'onFetchLibraryCompleted'), Reflux.connect(LibraryStore, "libraryStore"), Navigation, Reflux.listenerMixin],
 
     componentDidMount(){
         LibraryActions.fetchLibrary();
     },
 
-    onfetchLibraryCompleted() {
+    onFetchLibraryCompleted() {
 
-            if (this.props.params.ids === null){
-                history.pushState(null, '', HUD_URL);
-            }
-            var folderName = decodeURIComponent(this.props.params.name);
-            var ids = this.props.params.ids;
-            var idList = ids ?ids.split(',').map(Number) : [];
+        if (this.props.params.ids === null){
+            history.pushState(null, '', HUD_URL);
+        }
+        var folderName = decodeURIComponent(this.props.params.name);
+        var ids = this.props.params.ids;
+        var idList = ids ? ids.split(',').map(Number) : [];
 
-            for (var i = 0; i < this.state.libraryStore.length; i++){
-                if (this.state.libraryStore[i].folder === folderName){
-                    var index = idList.indexOf(this.state.libraryStore[i].listing.id);
-                    if (index > -1) {
-                        idList.splice(index, 1);
-                    }
+        for (var i = 0; i < this.state.libraryStore.length; i++){
+            if (this.state.libraryStore[i].folder === folderName){
+                var index = idList.indexOf(this.state.libraryStore[i].listing.id);
+                if (index > -1) {
+                    idList.splice(index, 1);
                 }
             }
-            if (this.props.params.ids === null){
-                history.pushState(null, '', HUD_URL);
-            }
-            LibraryActions.makeSharedFolder(folderName, idList);
-            this.props.params.ids = null;
+        }
+        if (this.props.params.ids === null){
+            history.pushState(null, '', HUD_URL);
+        }
+        LibraryActions.makeSharedFolder(folderName, idList);
+        this.props.params.ids = null;
     },
 
     render: function() {

--- a/app/js/components/folder/Add.jsx
+++ b/app/js/components/folder/Add.jsx
@@ -6,16 +6,39 @@ var Reflux = require('reflux');
 var Router = require('react-router');
 var Navigation = Router.Navigation;
 var LibraryActions = require('../../actions/Library');
+var LibraryStore = require('../../store/Library');
+
+var {HUD_URL} = require('OzoneConfig');
 
 var FolderModal = React.createClass({
-    mixins: [Navigation, Reflux.ListenerMixin],
+    mixins: [Reflux.listenTo(LibraryActions.hasLoaded, 'onfetchLibraryCompleted'), Reflux.connect(LibraryStore, "libraryStore"), Navigation, Reflux.listenerMixin],
 
-    componentDidMount: function() {
-      var folderName = decodeURIComponent(this.props.params.name);
-      var ids = this.props.params.ids;
-      var idList = ids ?ids.split(',').map(Number) : [];
+    componentDidMount(){
+        LibraryActions.fetchLibrary();
+    },
 
-      LibraryActions.makeSharedFolder(folderName, idList);
+    onfetchLibraryCompleted() {
+
+            if (this.props.params.ids === null){
+                history.pushState(null, '', HUD_URL);
+            }
+            var folderName = decodeURIComponent(this.props.params.name);
+            var ids = this.props.params.ids;
+            var idList = ids ?ids.split(',').map(Number) : [];
+
+            for (var i = 0; i < this.state.libraryStore.length; i++){
+                if (this.state.libraryStore[i].folder === folderName){
+                    var index = idList.indexOf(this.state.libraryStore[i].listing.id);
+                    if (index > -1) {
+                        idList.splice(index, 1);
+                    }
+                }
+            }
+            if (this.props.params.ids === null){
+                history.pushState(null, '', HUD_URL);
+            }
+            LibraryActions.makeSharedFolder(folderName, idList);
+            this.props.params.ids = null;
     },
 
     render: function() {

--- a/app/js/components/library/FolderTile.jsx
+++ b/app/js/components/library/FolderTile.jsx
@@ -13,6 +13,7 @@ var RandomBase16 = require('../../util/RandomBase16');
 var CurrentProfileStore = require('ozp-react-commons/stores/CurrentProfileStore');
 var ProfileActions = require('ozp-react-commons/actions/ProfileActions');
 
+var LibraryApi = require('../../api/Library').LibraryApi;
 var LibraryActions = require('../../actions/Library');
 
 var FolderTitle = require('../folder/FolderTitle.jsx');
@@ -70,15 +71,14 @@ var FolderTile = React.createClass({
     },
 
     deleteFolder: function(folder, deletedFn){
-        //if(window.confirm("Delete folder?")){
-            LibraryActions.deleteFolder(folder);
-            LibraryActions.restoreFolderNotification({
-              folder: folder.name,
-              peer: CurrentProfileStore.profile.username,
-              message: ''
-            });
-            deletedFn(folder);
-        //}
+        LibraryActions.deleteFolder(folder);
+        LibraryApi.restore(
+            folder.name,
+            CurrentProfileStore.profile.username,
+            ""
+        ).then(function(response){
+            deletedFn(folder, response.id);
+        });
     },
 
     render: function() {

--- a/app/js/components/library/FolderTile.jsx
+++ b/app/js/components/library/FolderTile.jsx
@@ -71,13 +71,16 @@ var FolderTile = React.createClass({
     },
 
     deleteFolder: function(folder, deletedFn){
-        LibraryActions.deleteFolder(folder);
         LibraryApi.restore(
             folder.name,
             CurrentProfileStore.profile.username,
             ""
         ).then(function(response){
-            deletedFn(folder, response.id);
+            LibraryApi.deleteFolder(
+                folder.entries.get(0).id
+            ).then(function(){
+                deletedFn(folder, response.id);
+            });
         });
     },
 

--- a/app/js/components/library/index.jsx
+++ b/app/js/components/library/index.jsx
@@ -31,7 +31,8 @@ var Library = React.createClass({
             library: Immutable.List(),
             hasLoaded: 0,
             loadMsg: '',
-            deletedFolder: false
+            deletedFolder: false,
+            notificationId: null
         };
     },
 
@@ -70,12 +71,12 @@ var Library = React.createClass({
         }, 20000);
     },
 
-    deletedFolder: function(folder){
+    deletedFolder: function(folder, notificationId){
         var me = this;
-        me.setState({deletedFolder: folder});
+        me.setState({deletedFolder: folder, notificationId:notificationId});
 
         setTimeout(function() {
-           me.setState({deletedFolder: false});
+           me.setState({deletedFolder: false, notificationId: null});
        }, 10000);
     },
 
@@ -90,7 +91,10 @@ var Library = React.createClass({
         var url =`${HUD_URL}/#/add/${encodeURI(this.state.deletedFolder.name)}/${bookmarks}`;
 
         window.location.href = url;
-        this.setState({deletedFolder: false});
+
+        LibraryActions.restoreFolderNotificationRemoval( this.state.notificationId);
+
+        this.setState({deletedFolder: false, notificationId: null});
         e.preventDefault();
     },
 

--- a/app/js/store/FolderLibrary.js
+++ b/app/js/store/FolderLibrary.js
@@ -306,6 +306,10 @@ var FolderLibraryStore = Reflux.createStore({
                 return (ent instanceof Folder) &&
                     ent.name === data.name;
             });
+    },
+
+    onRestoreFolderNotificationRemoval: function(payload){
+          LibraryApi.removeFolderNotification(payload);
     }
 });
 

--- a/app/js/store/Library.js
+++ b/app/js/store/Library.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var Reflux = require('reflux');
-var Immutable = require('immutable');
 var LibraryActions = require('../actions/Library');
 var LibraryApi  = require('../api/Library').LibraryApi;
 var pass1 = false;
@@ -11,7 +10,7 @@ var pass1 = false;
  */
 var LibraryStore = Reflux.createStore({
     //the actual object storing the library records
-    library: Immutable.List(),
+    library: [],
 
     listenables: LibraryActions,
 
@@ -20,9 +19,9 @@ var LibraryStore = Reflux.createStore({
     },
 
     updateLibrary: function(entries) {
-        this.library = Immutable.List(entries.map(function(e) {
+        this.library = entries.map(function(e) {
             return Object.freeze(e);
-        }));
+        });
         this.trigger(this.library);
     },
 


### PR DESCRIPTION
Fixes issue where the add listing links will add multiple of the same
listing to existing folder.
This has become more apparent due to the new undelete feature.
Fixes functionality when undo is clicked from in-HUD popup, the system
notification is removed for the user.

Closes# AMLNG-887

**Description**
If a user has a bookmark folder (Animals) and goes to the URL to add/share a bookmark folder of the same name, with the same bookmarks, those bookmarks are duplicated, rather than just adding new ones. The duplicates are unnecessary, and can cause issues with page reloading.

**Acceptance Criteria**
A shared bookmark folder link will not duplicate bookmarks the user already has in a folder of the same name.

**How to Test**
Pull this branch. 
Go into a folder and copy the share address. 
Pasting the share address into your browser and going to it, the Hud should not change. 
Delete a listing from the folder and redo the previous steps, the folder should be back to the way it was. 

Delete the folder, Click undo. There should be no new notifications after reloading the site.
Delete the folder again. Do not click undo. There should be a notification after reloading the site. 