### PR TITLE
fix(fonts): console errors

### DIFF
--- a/gulp/tasks/fonts.js
+++ b/gulp/tasks/fonts.js
@@ -10,7 +10,7 @@ var FONT_PATHS = [
 ];
 
 gulp.task('fonts', function () {
-    var filterFonts = filter('**/*.{eot,svg,ttf,woff}');
+    var filterFonts = filter('**/*.{eot,svg,ttf,woff,woff2}');
 
     return gulp.src(FONT_PATHS)
         .pipe(filterFonts)


### PR DESCRIPTION
Remove console errors by including fonts in Gulp tasks file filter.

Closes #AMLNG-918

**Acceptance Criteria**
Removes warnings for Fonts in Console on HUD.
This does not address the Piwik server error (non-issue) or the possible favicon missing issue (believed to be a race condition).

**How To Test**
Pull this branch. 
Open HUD. Check Console for errors.